### PR TITLE
Sync run requirement pins with requirments txt

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -10,9 +10,10 @@ export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
 
 
-endgroup "Start Docker"
+( endgroup "Start Docker" ) 2> /dev/null
 
-startgroup "Configuring conda"
+( startgroup "Configuring conda" ) 2> /dev/null
+
 export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
@@ -36,34 +37,38 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-endgroup "Configuring conda"
+
+( endgroup "Configuring conda" ) 2> /dev/null
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda debug"
+
     # Drop into an interactive shell
     /bin/bash
 else
-    startgroup "Running conda $BUILD_CMD"
     conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda build"
-    startgroup "Validating outputs"
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
-    endgroup "Validating outputs"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-        endgroup "Uploading packages"
     fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
 fi
+
+( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -13,18 +13,23 @@ function startgroup {
         travis )
             echo "$1"
             echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::group::$1";;
         * )
             echo "$1";;
     esac
-}
+} 2> /dev/null
 
 function endgroup {
     # End a foldable group of log lines
     # Pass a single argument, quoted
+
     case ${CI:-} in
         azure )
             echo "##[endgroup]";;
         travis )
             echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::endgroup::";;
     esac
-}
+} 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -7,7 +7,7 @@
 
 source .scripts/logging_utils.sh
 
-startgroup "Configure Docker"
+( startgroup "Configure Docker" ) 2> /dev/null
 
 set -xeo pipefail
 
@@ -69,9 +69,11 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
-endgroup "Configure Docker"
 
-startgroup "Start Docker"
+( endgroup "Configure Docker" ) 2> /dev/null
+
+( startgroup "Start Docker" ) 2> /dev/null
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
@@ -95,3 +97,6 @@ docker run ${DOCKER_RUN_ARGS} \
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"
+
+# This closes the last group opened in `build_steps.sh`
+( endgroup "Final checks" ) 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Installing `awswrangler` from the `conda-forge` channel can be achieved by addin
 
 ```
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 ```
 
 Once the `conda-forge` channel has been enabled, `awswrangler` can be installed with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,19 +17,19 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<3.9
+    - python >=3.6,<3.10
     - pip
   run:
-    - python >=3.6,<3.9
+    - python >=3.6,<3.10
     - boto3 >=1.12.49,<2.0.0
     - botocore >=1.15.49,<2.0.0
     - numpy >=1.18.0,<1.21.0
     - pandas >=1.1.0,<1.3.0
     - pyarrow >=2.0.0,<3.1.0
-    - redshift_connector ~=2.0.0
+    - redshift-connector ~=2.0.0
     - pymysql >=0.9.0,<1.1.0
     - pg8000 >=1.16.0,<1.19.0
-    - openpyxl
+    - openpyxl ~=3.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.18.0,<1.21.0
     - pandas >=1.1.0,<1.3.0
     - pyarrow >=2.0.0,<3.1.0
-    - redshift-connector ~=2.0.0
+    - redshift_connector ~=2.0.0
     - pymysql >=0.9.0,<1.1.0
     - pg8000 >=1.16.0,<1.19.0
     - openpyxl ~=3.0.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
The run requirements in the recipe where out of sync with the requirements.txt for version 2.6: https://github.com/awslabs/aws-data-wrangler/blob/2.6.0/requirements.txt. This leads to problems installing with Python=3.9, see: https://github.com/conda-forge/awswrangler-feedstock/issues/80
<!--
Please add any other relevant info below:
-->
Out of interest: Isn't there some mechanism that automatically infers the requirements from pypi so that this manual step is not needed?